### PR TITLE
Update set-root-p-element.js

### DIFF
--- a/src/plugins/core/set-root-p-element.js
+++ b/src/plugins/core/set-root-p-element.js
@@ -6,6 +6,12 @@ define(function () {
    */
 
   'use strict';
+  
+  function getChromeVersion () {
+    var raw = window.navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
+
+    return raw ? parseInt(raw[2], 10) : false;
+  }
 
   return function () {
     return function (scribe) {
@@ -17,11 +23,15 @@ define(function () {
          * browsers(?) will position the caret outside of the P when the scribe is
          * focused.
          */
+        
+        var chromeVersion = getChromeVersion();
 
         // Force IE10 to not include br otherwise a linebreak is always included
         // in the textarea.
         if(window.navigator.userAgent.match(/MSIE 10/)) {
           scribe.setContent('<p></p>');
+        } else if (chromeVersion && chromeVersion >= 95) {
+          // Chrome 95 hangs when initial content is set
         } else {
           scribe.setContent('<p><br></p>');
         }


### PR DESCRIPTION
Chrome 95 has issues with setting p tag when the content of the text area is blank.
https://github.com/madebymany/sir-trevor-js/issues/589

On publish set a tag and then link version to sir-trevor and publish new version.